### PR TITLE
Fixed typo "Tansponder Type"

### DIFF
--- a/PlaneAlerter/Email Content Config.Designer.cs
+++ b/PlaneAlerter/Email Content Config.Designer.cs
@@ -59,7 +59,7 @@
             this.transponderTypeCheckBox.Name = "transponderTypeCheckBox";
             this.transponderTypeCheckBox.Size = new System.Drawing.Size(110, 17);
             this.transponderTypeCheckBox.TabIndex = 1;
-            this.transponderTypeCheckBox.Text = "Tansponder Type";
+            this.transponderTypeCheckBox.Text = "Transponder Type";
             this.transponderTypeCheckBox.UseVisualStyleBackColor = true;
             // 
             // plHidden


### PR DESCRIPTION
Just noticed this typo in the Email Content Config dialogue.