### PR TITLE
Ensure the Lat/Long values used in the aircraftlist URL have Dots, not Commas.

### DIFF
--- a/PlaneAlerter/Checker.cs
+++ b/PlaneAlerter/Checker.cs
@@ -326,9 +326,9 @@ namespace PlaneAlerter {
 				//Generate aircraftlist.json url
 				string url = "";
 				if (!Settings.acListUrl.Contains("?"))
-					url = Settings.acListUrl + "?trFmt=f&refreshTrails=1&lat=" + Settings.Lat + "&lng=" + Settings.Long;
+					url = Settings.acListUrl + "?trFmt=f&refreshTrails=1&lat=" + Convert.ToString(Settings.Lat).Replace(",", ".") + "&lng=" + Convert.ToString(Settings.Long).Replace(",", ".");
 				else
-					url = Settings.acListUrl + "&trFmt=f&refreshTrails=1&lat=" + Settings.Lat + "&lng=" + Settings.Long;
+					url = Settings.acListUrl + "&trFmt=f&refreshTrails=1&lat=" + Convert.ToString(Settings.Lat).Replace(",", ".") + "&lng=" + Convert.ToString(Settings.Long).Replace(",", ".");
 				//Create request
 				request = (HttpWebRequest)WebRequest.Create(url);
 				request.Method = "GET";


### PR DESCRIPTION
Depending on one's localization the implicit conversion of Decimal to a String uses a Comma "," instead of a Dot "." (the German localization de-DE is an example of this). If this happens, the aircraftlist.json retrieved from VRS will not include a distance ("Dst") value. This then leads to the Distance condition not working, as well as outlandish distance numbers reported in the sent e-mails.

This fixes that by proactively replacing "," with "." when assembling the query URL.